### PR TITLE
[FRONT] Refactorizar front

### DIFF
--- a/src/templates/execution_plan.html
+++ b/src/templates/execution_plan.html
@@ -73,9 +73,17 @@
                               </tbody>
                         </table>
                     </div>
-                    <div class="text-right">
-                        <a class="btn btn-secondary" href={{ url_for("view_controller.execution_plan_list") }}>Volver</a>
-                    </div>
+                    <div class="d-flex align-items-center">
+                        <div class="text-left">
+                            <button class="btn btn-outline-secondary" onclick="duplicateSimulation({{ execution_plan.id }})">
+                                <i class="fa-solid fa-clipboard"></i>
+                                Duplicar Simulación
+                            </button>
+                        </div>
+                        <div class="text-right ml-auto">
+                            <a class="btn btn-secondary" href="{{ url_for('view_controller.execution_plan_list') }}">Volver</a>
+                        </div>
+                    </div>                    
                 {% else %}
                     <div class="form-group">
                         <label for="plan_name"><h5>Nombre del plan</h5></label>
@@ -190,6 +198,19 @@
         function editSimulation(id) {
             let new_simulation_url = `{{ url_for('view_controller.execution_plan_edit_view', execution_plan_id='')}}${id}`
             window.location.href = new_simulation_url
+        }
+
+        function duplicateSimulation(id) {
+            let copy_url = `{{ url_for('execution_plan_controller.copy', id='') }}${id}`;
+                          
+            fetch(copy_url, {method: 'POST'})
+            .then(response => {
+                list_url = "{{ url_for('view_controller.execution_plan_list') }}";
+                window.location.href = list_url;
+            })
+            .catch(error => {
+                console.error('Error al duplicar la simulación', error);
+            });
         }
 
     </script>

--- a/src/templates/execution_plan.html
+++ b/src/templates/execution_plan.html
@@ -4,6 +4,9 @@
         <div class="d-flex justify-content-between pb-4">
             {% if readonly %}
                 <h2>Simulación #{{ execution_plan.id }}</h2>
+                <button type="button" class="btn btn-outline-secondary" title="Editar simulacion" onclick="editSimulation({{ execution_plan.id }})">
+                    <i class="fa-solid fa-pencil"></i>
+                </button>
             {% else %}
                 <h2>Nueva simulación</h2>
             {% endif %}
@@ -183,6 +186,11 @@
             $( "#execution_plan_output_table_body" ).append( new_row );
             removeRowListener(".remove-row-execution-plan-output")
         });
+
+        function editSimulation(id) {
+            let new_simulation_url = `{{ url_for('view_controller.execution_plan_edit_view', execution_plan_id='')}}${id}`
+            window.location.href = new_simulation_url
+        }
 
     </script>
     <style>

--- a/src/templates/execution_plan_list.html
+++ b/src/templates/execution_plan_list.html
@@ -64,12 +64,6 @@
                 </button>
             `;
 
-            let edit_button = `
-                <button type="button" class="btn btn-outline-secondary" title="Editar simulacion" onclick="editSimulation(${row['id']})">
-                    <i class="fa-solid fa-code-compare"></i>
-                </button>
-            `;
-
             let cancel_button = `
                 <button type="button" class="btn btn-outline-danger"  ${row['status'] == "PENDING" || row['status'] == "RUNNING" ? '' : 'disabled data-toggle="tooltip" data-placement="bottom" title="Simulación Cancelada"'} onclick="cancelSimulation(${row['id']})">
                     <i class="fa-solid fa-times"></i>
@@ -81,7 +75,6 @@
                     ${update_button}
                     ${start_button}
                     ${duplicate_button}
-                    ${edit_button}
                     ${cancel_button}
             `
         }
@@ -127,11 +120,6 @@
             .catch(error => {
                 console.error('Error al duplicar la simulación', error);
             });
-        }
-    
-        function editSimulation(id) {
-            let new_simulation_url = `{{ url_for('view_controller.execution_plan_edit_view', execution_plan_id='')}}${id}`
-            window.location.href = new_simulation_url
         }
 
         function cancelSimulation(id) {

--- a/src/templates/execution_plan_list.html
+++ b/src/templates/execution_plan_list.html
@@ -58,12 +58,6 @@
                 </button>
             `;
            
-            let duplicate_button = `
-                <button type="button" class="btn btn-outline-secondary mr-2" onclick="duplicateSimulation(${row['id']})" title="Duplicar Simulación">
-                    <i class="fa-solid fa-clipboard"></i>
-                </button>
-            `;
-
             let cancel_button = `
                 <button type="button" class="btn btn-outline-danger"  ${row['status'] == "PENDING" || row['status'] == "RUNNING" ? '' : 'disabled data-toggle="tooltip" data-placement="bottom" title="Simulación Cancelada"'} onclick="cancelSimulation(${row['id']})">
                     <i class="fa-solid fa-times"></i>
@@ -74,7 +68,6 @@
                 <div class="d-flex justify-content-around">
                     ${update_button}
                     ${start_button}
-                    ${duplicate_button}
                     ${cancel_button}
             `
         }
@@ -109,19 +102,6 @@
             });
         }
     
-        function duplicateSimulation(id) {
-            let copy_url = `{{ url_for('execution_plan_controller.copy', id='') }}${id}`;
-                          
-            fetch(copy_url, {method: 'POST'})
-            .then(response => {
-                console.log('Duplicación exitosa');
-                window.location.reload();
-            })
-            .catch(error => {
-                console.error('Error al duplicar la simulación', error);
-            });
-        }
-
         function cancelSimulation(id) {
             let cancel_url = `{{ url_for('execution_plan_controller.cancel', execution_id='') }}${id}`;
 


### PR DESCRIPTION
Refactor del front de la aplicación. Se elimino de la vista de la lista de simulaciones los botones duplicar y editar, y se agregaron a la vista de inspeccionar la simulacion.
![image](https://github.com/manulon/gesina-core-api-2.0/assets/45469722/5f3ddb5b-2e7b-42b7-9ec6-7da1d287d67e)
![image](https://github.com/manulon/gesina-core-api-2.0/assets/45469722/4d6061e2-4666-4085-b296-e2cbe0d13fec)
