### PR TITLE
[BUG FIXED] new version: /schedule_task/tasks - wrong version: /sched…

### DIFF
--- a/src/static/openapi.yaml
+++ b/src/static/openapi.yaml
@@ -467,7 +467,7 @@ paths:
                   error:
                     type: string
                     description: Additional error information
-  /schedule_task/all:
+  /schedule_task/tasks:
     get:
       tags:
         - Scheduled Tasks


### PR DESCRIPTION
Fede, vos pusiste en la tarea que era un problema de formato de fecha, pero me parece que el único problema es que el endpoint es /schedule_task/tasks y en postman y en swagger estaba como /schedule_task/all

La tarea era:
[BUG] el /all the scheduled task falla con curl -X GET "http://localhost:5001/api/schedule_task/all?date_from=2021-01-01T00%3A00%3A00&date_to=2024-04-01T00%3A00%3A00" -H "accept: application/json". Validar Fecha y formato en el endpoint

Decime si te parece ok, ya funciona ahora

