### PR TITLE
Fix bug for repeated scheduled tasks

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -154,6 +154,17 @@ def check_for_scheduled_tasks():
                 scheduler.remove_job(job_id)
 
 
+
+
 if __name__ == "__main__":
+    job_store = jobstores["default"]
+    # Se eliminan todos los jobs que no tienen id numerico , son jobs seteados en ejecuciones anteriores de tipo
+    # check_for_scheduled_tasks
+    for job in job_store.get_all_jobs():
+        if not job.id.isnumeric():
+            job_store.remove_job(job.id)
+
+
     scheduler.add_job(check_for_scheduled_tasks, "interval", seconds=10)
     scheduler.start()
+


### PR DESCRIPTION
Aca habia un bug que cada vez que se iniciaba la app se creaba un job de tipo check_for_scheduled_tasks
Este corre cada 10 segundos, el problema es que cada vez que se apaga la app queda el job creado y terminan ejecutandose multiples al mismo tiempo, cosa que no es esperado.

las 3 lineas agregadas se encargan de borrar los jobs que tienen ids no numericos, que siempre son los creados en la linea mas abajo.